### PR TITLE
Add test for Tenable function

### DIFF
--- a/Tenable/TenableFunction/index.test.js
+++ b/Tenable/TenableFunction/index.test.js
@@ -1,0 +1,37 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const Module = require('node:module');
+
+// Mock external modules used by the handler
+const mocks = {
+  axios: { post: async () => ({ status: 200 }) },
+  '@azure/identity': { DefaultAzureCredential: function() {} },
+  '@azure/keyvault-secrets': {
+    SecretClient: class {
+      async getSecret() { return { value: 'dummy' }; }
+    }
+  }
+};
+
+const originalLoad = Module._load;
+Module._load = function(request, parent, isMain) {
+  if (mocks[request]) {
+    return mocks[request];
+  }
+  return originalLoad(request, parent, isMain);
+};
+
+const handler = require('./index');
+Module._load = originalLoad;
+
+process.env.KEYVAULT_URL = 'https://example.com';
+
+test('returns a response body when ipAddresses are provided', async () => {
+  const context = { log: () => {}, res: null };
+  const req = { body: { ipAddresses: ['1.1.1.1'] } };
+
+  await handler(context, req);
+
+  assert.ok(context.res, 'context.res should be defined');
+  assert.ok(context.res.body, 'response body should be defined');
+});

--- a/Tenable/package.json
+++ b/Tenable/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "func start",
-    "test": "echo \"No tests specified.\" && exit 0"
+    "test": "node --test TenableFunction/index.test.js"
   },
   "dependencies": {
     "axios": "^0.21.1",


### PR DESCRIPTION
## Summary
- add basic test for TenableFunction handler
- run test using Node's built-in test runner

## Testing
- `npm test --silent` in `Tenable`

------
https://chatgpt.com/codex/tasks/task_b_6858ea3a3884832ba3b520c2d031c116